### PR TITLE
Add linting capabilities to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Sphinx documentation
+docs/_build/
+
+# Junk files
+.DS_Store
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+dist: xenial
+language: python
+python:
+  - "3.7"
+
+sudo: false
+cache: pip
+
+install:
+  - pip install sphinx~=1.8.5
+  - pip install sphinx-rtd-theme~=0.4.3 
+
+script: cd docs && sphinx-build -nWT -b dummy . _build/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext validate
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -47,6 +47,7 @@ help:
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 	@echo "  coverage   to run coverage check of the documentation (if enabled)"
+	@echo "  validate   to validate no warnings or missing references are present"
 
 clean:
 	rm -rf $(BUILDDIR)/*
@@ -190,3 +191,8 @@ pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+
+validate:
+	$(SPHINXBUILD) -b dummy -nW $(ALLSPHINXOPTS) $(BUILDDIR)
+	@echo
+	@echo "Validation finished."	


### PR DESCRIPTION
Add `validate` target in Makefile to check for warnings and missing references.
Add Travis-CI configuration file to break on warnings and missing references.

Signed-off-by: Piotr PAWLICKI <piotrek@seovya.net>